### PR TITLE
[Opti position] use row_number/partition_by to optimize computing position

### DIFF
--- a/app/api/routes/user.py
+++ b/app/api/routes/user.py
@@ -6,7 +6,7 @@ from app.crud.user import create_user_if_not_exist
 from app.db.session import get_db
 from app.schemas import UserCreate, UserOut
 from app.schemas.waiting_list import WaitingListOut
-from app.services.waiting_list import compute_position_for_waitinglist_entries
+from app.services.waiting_list import compute_position_for_waitinglist_entries, format_position_for_waitinglist_entries
 
 router = APIRouter()
 
@@ -28,4 +28,4 @@ def get_user_entries(user_id: int, db: Session = Depends(get_db)):
     :param db:
     :return: list of WaitingListEntries associated to user_id
     """
-    return compute_position_for_waitinglist_entries(db, waiting_list.get_user_waitinglist_entries(db, user_id))
+    return format_position_for_waitinglist_entries(waiting_list.get_entries_with_position(db, user_id=user_id))

--- a/app/api/routes/waiting_list.py
+++ b/app/api/routes/waiting_list.py
@@ -5,7 +5,8 @@ from sqlalchemy.orm import Session
 from app.db.session import get_db
 from app.schemas import WaitingListCreate, WaitingListOut
 from app.crud import waiting_list
-from app.services.waiting_list import compute_position_for_waitinglist_entries, compute_position_for_waitinglist_entry
+from app.services.waiting_list import compute_position_for_waitinglist_entries, compute_position_for_waitinglist_entry, \
+    format_position_for_waitinglist_entries
 
 router = APIRouter()
 
@@ -51,4 +52,4 @@ def organizer_view(event_id: Optional[str] = Query(None), representation_id: Opt
     :param db: SQLAlchemy session
     :return: list of WaitingListOut including positions in the queue.
     """
-    return compute_position_for_waitinglist_entries(db, waiting_list.get_entries_for_event_rep_offer(db=db, event_id=event_id, representation_id=representation_id, offer_id=offer_id))
+    return format_position_for_waitinglist_entries(waiting_list.get_entries_with_position(db, event_id=event_id, representation_id=representation_id, offer_id=offer_id))

--- a/app/crud/waiting_list.py
+++ b/app/crud/waiting_list.py
@@ -1,4 +1,6 @@
 from typing import Optional
+
+from sqlalchemy import select, func
 from sqlalchemy.orm import Session
 from app.exceptions.inventory_exceptions import InventoryNotFound
 from app.exceptions.offer_exceptions import OfferNotFound
@@ -93,7 +95,7 @@ def delete_entry(db: Session, entry_id: int):
     db.commit()
 
 
-def get_entries_for_event_rep_offer(db: Session, event_id: Optional[str], representation_id: Optional[str], offer_id: Optional[str]):
+def get_entries_for_event_rep_offer(db: Session, event_id: Optional[str] = None, representation_id: Optional[str] = None, offer_id: Optional[str] = None):
     """
     Returns all waitinglist entries matching intersection of input filters
     :param db: SQLAlchemy session
@@ -114,3 +116,36 @@ def get_entries_for_event_rep_offer(db: Session, event_id: Optional[str], repres
         query = query.join(Representation).join(Event).filter(Event.id == event_id)
 
     return query.order_by(WaitingListEntry.timestamp.asc()).all()
+
+
+def get_entries_with_position(db: Session, event_id: Optional[str] = None, representation_id: Optional[str] = None, offer_id: Optional[str] = None, user_id: Optional[int] = None):
+    """
+    Returns all waitinglist entries matching intersection of input filters
+    :param db: SQLAlchemy session
+    :param event_id: filter value for events
+    :param representation_id: filter value for representation
+    :param offer_id: filter value for offer
+    :return: waitinglist entries matching intersection of input filters.
+    """
+    query = select(
+        WaitingListEntry,
+        func.row_number().over(
+            partition_by=(WaitingListEntry.offer_id, WaitingListEntry.representation_id),
+            order_by=WaitingListEntry.timestamp.asc()
+        ).label("position")
+    )
+
+    if representation_id:
+        query = query.filter(WaitingListEntry.representation_id == representation_id)
+
+    if offer_id:
+        query = query.filter(WaitingListEntry.offer_id == offer_id)
+
+    if user_id:
+        query = query.filter(WaitingListEntry.user_id == user_id)
+
+    if event_id:
+        #we checked at insert for waitingList that representation.event_id = offer.event_id
+        query = query.join(Representation).join(Event).filter(Event.id == event_id)
+
+    return db.execute(query).all()

--- a/app/services/waiting_list.py
+++ b/app/services/waiting_list.py
@@ -1,3 +1,4 @@
+from sqlalchemy import Sequence, Row
 from sqlalchemy.orm import Session
 
 from app.crud.waiting_list import get_position_for_waitinglist_entry
@@ -16,3 +17,6 @@ def compute_position_for_waitinglist_entry(db: Session, entry: WaitingListEntry)
 def compute_position_for_waitinglist_entries(db: Session, entries: list[WaitingListEntry]) -> list[WaitingListOut]:
     """Computes position for list of Waitinglist entries."""
     return [compute_position_for_waitinglist_entry(db, e) for e in entries]
+
+def format_position_for_waitinglist_entries(entries: Sequence[Row]) -> list[WaitingListOut]:
+    return [WaitingListOut.model_validate(row[0], from_attributes=True).model_copy(update={"position": row[1]}) for row in entries]


### PR DESCRIPTION
Use ROW_NUMBER/Partition_by to compute all position for multiple waitinglist entries at once instead of doing 1 request per entry.